### PR TITLE
gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ dmypy.json
 cython_debug/
 
 # Mac DS_Store
-.DS_Stre
+.DS_Store
 
 # wandb folder
 wandb/


### PR DESCRIPTION
.gitignore에 오타가 있어서 수정하려 합니다ㅠㅠ 맥에서 작업할 때 `.DS_Store`가 올라가는 문제 방지용이에요!