### PR TITLE
Detach loss before accumulation

### DIFF
--- a/dkt/trainer.py
+++ b/dkt/trainer.py
@@ -178,9 +178,11 @@ def train(train_loader, model, optimizer, args):
         if args.device == 'cuda':
             preds = preds.to('cpu').detach().numpy()
             targets = targets.to('cpu').detach().numpy()
+            loss = loss.to('cpu').detach().numpy()
         else: # cpu
             preds = preds.detach().numpy()
             targets = targets.detach().numpy()
+            loss = loss.detach().numpy()
 
         total_preds.append(preds)
         total_targets.append(targets)
@@ -222,9 +224,11 @@ def validate(valid_loader, model, args):
         if args.device == 'cuda':
             preds = preds.to('cpu').detach().numpy()
             targets = targets.to('cpu').detach().numpy()
+            loss = loss.to('cpu').detach().numpy()
         else:  # cpu
             preds = preds.detach().numpy()
             targets = targets.detach().numpy()
+            loss = loss.detach().numpy()
 
         total_preds.append(preds)
         total_targets.append(targets)


### PR DESCRIPTION
`update_params` 함수에서 `loss.backward()` 를 해준 후, average loss 계산을 위해 loss history 를 기록하는데 loss 가 detach 가 되지 않아 train, validation 을 반복 수행할 때 GPU 메모리가 필요 이상으로 사용되는 버그를 해결하는 PR 입니다.